### PR TITLE
something terribly misguided

### DIFF
--- a/src/useSpin.ts
+++ b/src/useSpin.ts
@@ -5,7 +5,7 @@ import { observablePool } from './recoil-appliation-store'
 import { getRandomSymbol } from './util'
 
 const useSetDial = () =>
-  useRecoilCallback(({ set }) => (i: number, nextSymbol: string) => {
+  useRecoilCallback((i: number) => ({ set }, nextSymbol: string) => {
     set(observablePool.instance(i), nextSymbol)
   })
 


### PR DESCRIPTION
With this change, the parameters to `useRecoilCallback` have accidentally been mixed up. The previous version was written correctly. This is a user error.

Also, with this change, `tsc --noEmit` faults on an assertion while it succeded with the previous version.

```txt
$ tsc --noEmit
/src/tsc-fault-useRecoilCallback\node_modules\typescript\lib\tsc.js:96888
                throw e;
                ^

Error: Debug Failure. Expected [object Object] === [object Object]. Parameter symbol already has a cached type which differs from newly assigned type
    at assignParameterType (/src/tsc-fault-useRecoilCallback\node_modules\typescript\lib\tsc.js:64862:26)
    at assignContextualParameterTypes (/src/tsc-fault-useRecoilCallback\node_modules\typescript\lib\tsc.js:64827:21)
    at contextuallyCheckFunctionExpressionOrObjectLiteralMethod (/src/tsc-fault-useRecoilCallback\node_modules\typescript\lib\tsc.js:65229:29)
    at checkFunctionExpressionOrObjectLiteralMethod (/src/tsc-fault-useRecoilCallback\node_modules\typescript\lib\tsc.js:65208:13)
    at checkExpressionWorker (/src/tsc-fault-useRecoilCallback\node_modules\typescript\lib\tsc.js:66805:28)
    at checkExpression (/src/tsc-fault-useRecoilCallback\node_modules\typescript\lib\tsc.js:66707:38)
    at checkExpressionCached (/src/tsc-fault-useRecoilCallback\node_modules\typescript\lib\tsc.js:66411:24)
    at getReturnTypeFromBody (/src/tsc-fault-useRecoilCallback\node_modules\typescript\lib\tsc.js:64931:30)
    at contextuallyCheckFunctionExpressionOrObjectLiteralMethod (/src/tsc-fault-useRecoilCallback\node_modules\typescript\lib\tsc.js:65236:42)
    at checkFunctionExpressionOrObjectLiteralMethod (/src/tsc-fault-useRecoilCallback\node_modules\typescript\lib\tsc.js:65208:13)

Node.js v18.2.0
```

typescript-4.7.4
see package and yarn lock for more version details